### PR TITLE
#163073842 add test matching passwords

### DIFF
--- a/app/tests/test_user.py
+++ b/app/tests/test_user.py
@@ -21,6 +21,22 @@ class TestQuestioner(unittest.TestCase):
                             'username' : "bochie",
                             'registered' : "12-2-2019",
                             'isAdmin' : False,
+                            'password':"password",
+                            'confirm_password':"password"
+
+                            }
+        self.wrong_user_data = {
+                            'id' : 1,
+                            'firstname' : "james",
+                            'lastname' : "Kabochi",
+                            'othername' : "Gakuru",
+                            'email' : "bochirgfx@gmail.com",
+                            'phoneNumber' : "254722241161",
+                            'username' : "bochie",
+                            'registered' : "12-2-2019",
+                            'isAdmin' : False,
+                            'password':"password",
+                            'confirm_password':"confirm_password"
                             }
 
 
@@ -29,8 +45,17 @@ class TestQuestioner(unittest.TestCase):
 
         response = self.client.post(
             '/api/v1/auth/register', data=json.dumps(self.user_data), content_type='application/json')
+
         res = json.loads(response.data.decode())
         self.assertEqual(response.status_code, 201)
+    def test_wrong_password_registeration(self):
+        """Testing posting a meetup."""
+
+        response = self.client.post(
+            '/api/v1/auth/register', data=json.dumps(self.wrong_user_data), content_type='application/json')
+
+        res = json.loads(response.data.decode())
+        self.assertEqual(response.status_code, 400)
 
 
 


### PR DESCRIPTION
#### What does this PR do?
finishes the registration testing endpoinnt by checking for matcing passwords
#### Description of Task to be completed?
A programmer should be able to test for user registration
#### How should this be manually tested?
-clone the repo
-cd into Questioner-api
- run source venv/bin/activate in your terminal
- run pip install requirements.txt in your terminal
- run pytest to test
#### Any background context you want to provide?
No background context
#### What are the relevant pivotal tracker stories?
#163073842